### PR TITLE
Make Window Size Constraints DPI-Aware Using `GetDpiForWindow`

### DIFF
--- a/DPI-Aware/MainWindow.xaml
+++ b/DPI-Aware/MainWindow.xaml
@@ -13,7 +13,9 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid>
-
-    </Grid>
+    <StackPanel Orientation="Vertical" Margin="12">
+        <TextBlock Text="Window Size (DIPs):" FontWeight="Bold"/>
+        <TextBlock Text="{x:Bind WindowWidth, Mode=OneWay}"/>
+        <TextBlock Text="{x:Bind WindowHeight, Mode=OneWay}"/>
+    </StackPanel>
 </Window>


### PR DESCRIPTION
### Problem

The window size constraints (`PreferredMinimumWidth`, `PreferredMaximumWidth`, etc.) were originally set using **DIPs** (device-independent pixels). This is incorrect.

The `AppWindow` and `OverlappedPresenter` APIs operate in **physical pixels**, not DIPs. Passing raw DIP values leads to inconsistent sizing across different DPI settings (e.g., 100% vs 150% scaling).

For example, setting a min width of `500` DIPs will look smaller on a high-DPI screen unless it’s scaled to match the system’s physical pixel density.

---

### Fix

This PR fixes the issue by:

1. Calling `GetDpiForWindow(hWnd)` to retrieve the **current monitor DPI**.
2. Converting DIP values to physical pixels by applying `scaleFactor = dpi / 96.0`.
3. Using the scaled values when assigning `PreferredMinimumWidth`, `PreferredMaximumWidth`, etc.

```csharp
uint dpi = GetDpiForWindow(hWnd);
double scaleFactor = dpi / 96.0;
int minWidthPx = (int)Math.Round(500 * scaleFactor);
...
presenter.PreferredMinimumWidth = minWidthPx;
```

---

### Why This Matters

* **Consistency across DPIs**: Without this, the same min/max dimensions behave differently across monitors.
* **Correct API usage**: The platform expects **physical pixels**. Using DIPs is a misuse of the API and leads to UI inconsistency.
* **Future-proofing**: High-DPI displays are the norm. This makes the window constraints predictable and correct in all display environments.

---

### Summary

This change ensures that all window dimension constraints respect DPI scaling by explicitly converting DIPs to physical pixels using the correct DPI value from the OS. It aligns the behavior with platform expectations and removes layout inconsistency across screens.

---

### References
- [Resize a window in WinUI (part 0: what is DPI) - By *Ben Stolovitz* - 05/05/2025](https://ben.stolovitz.com/posts/resize_winui_window_part_0_dpi/)
- [GetDpiForWindow function (winuser.h)](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdpiforwindow)